### PR TITLE
Fix the td height

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -25,6 +25,7 @@
   border: 1px solid #efefef;
 }
 .player tr td {
+  height: 26px;
   padding: 5px;
 }
 .player tr:nth-child(even) {


### PR DESCRIPTION
The emojis for null data push the table rows to 26px, which makes the table rows an uneven height. This change styles them all a 26px, making the table easier to read.